### PR TITLE
Update bundled RxJava version to 1.1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-def RXJAVA_VERSION = '1.1.7'
+def RXJAVA_VERSION = '1.1.9'
 def ASSERTJ_VERSION = '2.5.0'
 
 dependencies {


### PR DESCRIPTION
Just got a conflict while it's possible to resolve it in Gradle itself it'd be nice if there's a new version that the latest one will be used.
