### PR TITLE
Add possibillity to use TestScheduler

### DIFF
--- a/src/main/java/br/ufs/github/rxassertions/NonBlockingObservableAssert.java
+++ b/src/main/java/br/ufs/github/rxassertions/NonBlockingObservableAssert.java
@@ -1,0 +1,92 @@
+package br.ufs.github.rxassertions;
+
+import org.assertj.core.api.Condition;
+
+import java.util.Collection;
+
+import rx.Observable;
+
+public class NonBlockingObservableAssert<T> {
+
+    private NonBlockingTestSubscriberAssertionsWrapper <T> wrapper;
+
+    public NonBlockingObservableAssert(Observable<T> actual) {
+        wrapper = new NonBlockingTestSubscriberAssertionsWrapper<>(actual);
+    }
+
+    public NonBlockingObservableAssert<T> completes() {
+        wrapper.completes();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> notCompletes() {
+        wrapper.notCompletes();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> emissionsCount(int count) {
+        wrapper.emissionsCount(count);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> fails() {
+        wrapper.fails();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> failsWithThrowable(Class thowableClazz) {
+        wrapper.failsWithThrowable(thowableClazz);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> emitsNothing() {
+        wrapper.emitsNothing();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> receivedTerminalEvent() {
+        wrapper.receivedTerminalEvent();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> withoutErrors() {
+        wrapper.withoutErrors();
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> expectedSingleValue(T expected) {
+        wrapper.expectedSingleValue(expected);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> expectedValues(Collection<T> ordered) {
+        wrapper.expectedValues(ordered);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> eachItemMatches(Condition<? super T> condition) {
+        wrapper.eachItemMatches(condition);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> oneEmissionMatches(Condition<? super T> condition) {
+        wrapper.oneEmissionMatches(condition);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> allItemsNotMaching(Condition<? super T> condition) {
+        wrapper.allItemsNotMaching(condition);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> emits(T... values) {
+        wrapper.emits(values);
+        return this;
+    }
+
+    public NonBlockingObservableAssert<T> failsOnCondition(Condition<? super Throwable> condition) {
+        wrapper.failsOnCondition(condition);
+        return this;
+    }
+}
+

--- a/src/main/java/br/ufs/github/rxassertions/NonBlockingTestSubscriberAssertionsWrapper.java
+++ b/src/main/java/br/ufs/github/rxassertions/NonBlockingTestSubscriberAssertionsWrapper.java
@@ -1,0 +1,114 @@
+package br.ufs.github.rxassertions;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Condition;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NonBlockingTestSubscriberAssertionsWrapper<T> extends
+      AbstractAssert<NonBlockingTestSubscriberAssertionsWrapper<T>, Observable<T>> {
+
+    private final TestSubscriber subscriber;
+
+    NonBlockingTestSubscriberAssertionsWrapper(Observable<T> actual) {
+        super(actual, NonBlockingTestSubscriberAssertionsWrapper.class);
+        subscriber = new TestSubscriber<>();
+        actual.subscribe(subscriber);
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> completes() {
+        assertThat(subscriber.getOnCompletedEvents()).isNotNull().isNotEmpty();
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> notCompletes() {
+        assertThat(subscriber.getOnCompletedEvents()).isNullOrEmpty();
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> emissionsCount(int count) {
+        assertThat(subscriber.getOnNextEvents()).isNotNull().isNotEmpty().hasSize(count);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> fails() {
+        assertThat(subscriber.getOnErrorEvents()).isNotNull().isNotEmpty();
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> failsWithThrowable(Class thowableClazz) {
+        assertThat(subscriber.getOnErrorEvents()).isNotNull();
+        assertThat(subscriber.getOnErrorEvents().get(0)).isInstanceOf(thowableClazz);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> emitsNothing() {
+        assertThat(subscriber.getOnNextEvents()).isEmpty();
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> receivedTerminalEvent() {
+        assertThat(subscriber.getOnCompletedEvents()).isNotNull();
+        assertThat(subscriber.getOnErrorEvents()).isNotNull();
+        assertThat(subscriber.getOnCompletedEvents().size() + subscriber.getOnErrorEvents().size()).isEqualTo(1);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> withoutErrors() {
+        assertThat(subscriber.getOnErrorEvents()).isNotNull().isEmpty();
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> expectedSingleValue(T expected) {
+        assertThat(subscriber.getOnNextEvents())
+              .isNotNull()
+              .isNotEmpty()
+              .hasSize(1);
+
+        assertThat(subscriber.getOnNextEvents().get(0)).isEqualTo(expected);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> expectedValues(T... expected) {
+        return expectedValues(Arrays.asList(expected));
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> expectedValues(Collection<T> ordered) {
+        assertThat(subscriber.getOnNextEvents())
+              .isNotNull()
+              .isNotEmpty()
+              .hasSameElementsAs(ordered);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> eachItemMatches(Condition<? super T> condition) {
+        assertThat(subscriber.getOnNextEvents()).are(condition);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> oneEmissionMatches(Condition<? super T> condition) {
+        assertThat(subscriber.getOnNextEvents()).areAtLeast(1, condition);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> allItemsNotMaching(Condition<? super T> condition) {
+        assertThat(subscriber.getOnNextEvents()).areNot(condition);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> emits(T... values) {
+        assertThat(subscriber.getOnNextEvents()).contains(values);
+        return this;
+    }
+
+    public NonBlockingTestSubscriberAssertionsWrapper<T> failsOnCondition(Condition<? super Throwable> condition) {
+        assertThat(subscriber.getOnErrorEvents()).areAtLeast(1, condition);
+        return this;
+    }
+}

--- a/src/main/java/br/ufs/github/rxassertions/RxAssertionsNonBlock.java
+++ b/src/main/java/br/ufs/github/rxassertions/RxAssertionsNonBlock.java
@@ -1,0 +1,29 @@
+package br.ufs.github.rxassertions;
+
+import rx.Completable;
+import rx.Observable;
+import rx.Single;
+import rx.observables.BlockingObservable;
+
+public final class RxAssertionsNonBlock {
+
+    public static <T> NonBlockingTestSubscriberAssertionsWrapper<T> assertThat(Observable<T> observable) {
+        return new NonBlockingTestSubscriberAssertionsWrapper<T>(observable);
+    }
+
+    public static <T> NonBlockingTestSubscriberAssertionsWrapper<T> assertThat(Completable observable) {
+        return assertThat(observable.toObservable());
+    }
+
+    public static <T> NonBlockingTestSubscriberAssertionsWrapper<T> assertThat(Single<T> observable) {
+        return assertThat(observable.toObservable());
+    }
+
+    public static <T> BlockingObservableAssert<T> assertThat(BlockingObservable<T> observable) {
+        return RxAssertions.assertThat(observable);
+    }
+
+    private RxAssertionsNonBlock() {
+        throw new AssertionError("No instances, please");
+    }
+}

--- a/src/test/java/br/ufs/github/rxassertions/tests/NonBlockingObservableAssertTest.java
+++ b/src/test/java/br/ufs/github/rxassertions/tests/NonBlockingObservableAssertTest.java
@@ -1,0 +1,196 @@
+package br.ufs.github.rxassertions.tests;
+
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import br.ufs.github.rxassertions.NonBlockingObservableAssert;
+import rx.Observable;
+import rx.schedulers.TestScheduler;
+
+public class NonBlockingObservableAssertTest  {
+
+    @Test
+    public void completesAssertion_ShouldPass() {
+        Observable<String> obs = Observable.just("a", "b");
+        new NonBlockingObservableAssert<>(obs).completes();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void completes_ChainingWithFail_ShouldFail() {
+        Observable<Void> obs = Observable.error(new RuntimeException());
+        new NonBlockingObservableAssert<>(obs).fails().completes();
+    }
+
+    @Test
+    public void completesShouldRespectScheduler() throws Exception {
+        TestScheduler scheduler = new TestScheduler();
+        Observable<String> obs = Observable.just("a", "b").subscribeOn(scheduler);
+        NonBlockingObservableAssert<String> assertion = new NonBlockingObservableAssert<>(obs);
+        assertion.notCompletes();
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.completes();
+    }
+
+    @Test
+    public void errorsShouldRespectScheduler() throws Exception {
+        TestScheduler scheduler = new TestScheduler();
+        Observable<Void> obs = Observable.<Void>error(new RuntimeException()).subscribeOn(scheduler);
+        NonBlockingObservableAssert<Void> assertion = new NonBlockingObservableAssert<>(obs);
+        assertion.withoutErrors();
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.fails();
+    }
+
+    @Test
+    public void onNextShouldRespectScheduler() throws Exception {
+        TestScheduler scheduler = new TestScheduler();
+        Observable<Long> obs = Observable.interval(1, TimeUnit.MILLISECONDS, scheduler);
+        NonBlockingObservableAssert<Long> assertion = new NonBlockingObservableAssert<>(obs);
+        assertion.emitsNothing();
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.emissionsCount(1);
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.emissionsCount(2);
+    }
+
+    @Test public void notCompletesAssertion_ShouldPass() {
+        Observable<Void> obs = Observable.error(new IllegalStateException());
+        new NonBlockingObservableAssert<>(obs).notCompletes();
+    }
+
+    @Test public void emissionsAssertion_ShouldPass() {
+        Observable<Integer> obs = Observable.range(1, 3);
+        new NonBlockingObservableAssert<>(obs).emissionsCount(3);
+    }
+
+    @Test public void failsAssertion_ShouldPass() {
+        Observable<Void> obs = Observable.error(new RuntimeException());
+        new NonBlockingObservableAssert<>(obs).fails();
+    }
+
+    @Test public void failsWithThrowableAssertion_ShouldPass() {
+        Observable<Void> obs = Observable.error(new RuntimeException());
+        new NonBlockingObservableAssert<>(obs).failsWithThrowable(RuntimeException.class);
+    }
+
+    @Test public void emitisNothingAssertion_ShouldPass() {
+        Observable<Void> obs = Observable.from(Collections.emptyList());
+        new NonBlockingObservableAssert<>(obs).emitsNothing();
+    }
+
+    @Test public void receivesTerminalEvent_OnCompleted_ShouldPass() {
+        Observable<String> obs = Observable.just("c", "d");
+        new NonBlockingObservableAssert<>(obs).receivedTerminalEvent();
+    }
+
+    @Test public void receivesTerminalEvents_OnError_ShouldPass() {
+        Observable<Void> obs = Observable.error(new RuntimeException());
+        new NonBlockingObservableAssert<>(obs).receivedTerminalEvent();
+    }
+
+    @Test public void withoutErrors_ShouldPass() {
+        Observable<String> obs = Observable.just("RxJava");
+        new NonBlockingObservableAssert<>(obs).withoutErrors();
+    }
+
+    @Test public void withExpectedSingleValue_ShouldPass() {
+        Observable<String> obs = Observable.just("Expected");
+        new NonBlockingObservableAssert<>(obs).expectedSingleValue("Expected");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void withUnexpectedSingleValue_ShouldFail() {
+        Observable<String> obs = Observable.just("Unexpected");
+        new NonBlockingObservableAssert<>(obs).expectedSingleValue("Expected");
+    }
+
+    @Test public void withConditionsMatchingEachItem_ShoulPass() {
+        List<String> expected = Arrays.asList("These", "are", "Expected", "Values");
+        Observable<String> obs = Observable.from(expected);
+
+        Condition<String> atLeastTwoChars = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value.length() >= 2;
+            }
+        };
+
+        Condition<String> noMoreThanTenChars = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value.length() <= 10;
+            }
+        };
+
+        new NonBlockingObservableAssert<>(obs)
+              .eachItemMatches(atLeastTwoChars)
+              .eachItemMatches(noMoreThanTenChars);
+    }
+
+    @Test public void withConditionsMatchingOnlyOneItem_ShoulPass() {
+        List<String> expected = Arrays.asList("These", "are", "Expected", "Values");
+        Observable<String> obs = Observable.from(expected);
+
+        Condition<String> exactlyThreeChars = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value.length() == 3;
+            }
+        };
+
+        new NonBlockingObservableAssert<>(obs).oneEmissionMatches(exactlyThreeChars);
+    }
+
+    @Test public void withConditionsNotMatchingAnyItems_ShoulPass() {
+        List<String> expected = Arrays.asList("These", "are", "Expected", "Values");
+        Observable<String> obs = Observable.from(expected);
+
+        Condition<String> nullString = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value == null;
+            }
+        };
+
+        new NonBlockingObservableAssert<>(obs).allItemsNotMaching(nullString);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void withConditionsNotMathchingEachItem_ShouldFail() {
+        List<String> expected = Arrays.asList("These", "two");
+        Observable<String> obs = Observable.from(expected);
+
+        Condition<String> moreThanFourChars = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value.length() >= 4;
+            }
+        };
+
+        new NonBlockingObservableAssert<>(obs).eachItemMatches(moreThanFourChars);
+    }
+
+    @Test public void withContains_ShoudPass() {
+        List<String> expected = Arrays.asList("Expected", "Values");
+        Observable<String> obs = Observable.from(expected);
+        new NonBlockingObservableAssert<>(obs).emits("Values");
+    }
+
+    @Test(expected = AssertionError.class) public void withContains_ShoudFail() {
+        List<String> expected = Arrays.asList("Expected", "Values");
+        Observable<String> obs = Observable.from(expected);
+        new NonBlockingObservableAssert<>(obs).emits("RxJava");
+    }
+
+    @Test public void failsAssertion_WithCondition_ShouldPass() {
+        Observable<Void> obs = Observable.error(new NullPointerException("Desired message"));
+
+        Condition<Throwable> messageChecking = new Condition<Throwable>() {
+            @Override public boolean matches(Throwable value) {
+                return value.getMessage().contains("Desired message");
+            }
+        };
+
+        new NonBlockingObservableAssert<>(obs).failsOnCondition(messageChecking);
+    }
+}

--- a/src/test/java/br/ufs/github/rxassertions/tests/RxAssertionsNonBlockTest.java
+++ b/src/test/java/br/ufs/github/rxassertions/tests/RxAssertionsNonBlockTest.java
@@ -1,0 +1,140 @@
+package br.ufs.github.rxassertions.tests;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import br.ufs.github.rxassertions.RxAssertionsNonBlock;
+import rx.Completable;
+import rx.Observable;
+import rx.Single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RxAssertionsNonBlockTest {
+
+    @Test
+    public void factoryMethod_BlockingObservable_ReturnsNotNull() {
+        Assertions.assertThat(RxAssertionsNonBlock.assertThat(Observable.just(1).toBlocking()))
+              .isNotNull();
+    }
+
+    @Test public void factoryMethod_RegularObservable_ReturnsNotNull() {
+        assertThat(RxAssertionsNonBlock.assertThat(Observable.just("Test")))
+              .isNotNull();
+    }
+
+    @Test public void factoryMethod_Single_ReturnsNotNull() {
+        Single<Boolean> single = Single.fromCallable(() -> Boolean.TRUE);
+        assertThat(RxAssertionsNonBlock.assertThat(single)).isNotNull();
+    }
+
+    @Test public void factoryMethod_Completable_ReturnsNotNull() {
+        Completable completable = Completable.fromCallable(() -> "Done");
+        assertThat(RxAssertionsNonBlock.assertThat(completable)).isNotNull();
+    }
+
+    @Test public void emissionsCount() {
+        RxAssertionsNonBlock.assertThat(Observable.range(1, 10))
+              .emissionsCount(10);
+    }
+
+    @Test public void canChain_TwoAssertions() {
+        RxAssertionsNonBlock.assertThat(Observable.range(1, 5))
+              .emissionsCount(5)
+              .completes();
+    }
+
+    @Test public void simpleFail() {
+        Observable<?> error = Observable.error(new IllegalArgumentException());
+        RxAssertionsNonBlock.assertThat(error).fails().notCompletes();
+    }
+
+    @Test public void failWithException() {
+        Observable<?> error = Observable.error(new IllegalStateException());
+        RxAssertionsNonBlock.assertThat(error).failsWithThrowable(IllegalStateException.class);
+    }
+
+    @Test public void noEmissions() {
+        RxAssertionsNonBlock.assertThat(Observable.empty())
+              .emitsNothing()
+              .completes()
+              .withoutErrors();
+    }
+
+    @Test public void regularObservable_CompletesWithEmissions() {
+        RxAssertionsNonBlock.assertThat(Observable.just("RxJava", "Assertions"))
+              .completes()
+              .withoutErrors()
+              .emits("RxJava", "Assertions");
+    }
+
+    @Test public void completable_completesWithoutErrors() {
+        Completable trivial = Completable.fromObservable(Observable.range(1, 5));
+        RxAssertionsNonBlock.assertThat(trivial)
+              .completes()
+              .withoutErrors();
+    }
+
+    @Test public void single_CompletesWithExpectedValue() {
+        Single<String> single = Single.fromCallable(() -> "RxJava");
+        RxAssertionsNonBlock.assertThat(single).completes().expectedSingleValue("RxJava");
+    }
+
+    @Test public void multipleEmissions_AreMatchedOnCondition() {
+        List<String> expected = Arrays.asList("These", "are", "Expected", "Values");
+        Observable<String> values = Observable.from(expected);
+
+        Condition<String> notNullAndNotEmpty = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value != null && !value.isEmpty();
+            }
+        };
+
+        RxAssertionsNonBlock.assertThat(values)
+              .completes()
+              .eachItemMatches(notNullAndNotEmpty);
+    }
+
+    @Test public void singleEmission_IsMatchedOnCondition() {
+        List<String> expected = Arrays.asList("These", "are", "the", "values");
+        Observable<String> values = Observable.from(expected);
+
+        Condition<String> withThreeChars = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value != null && value.length() == 3;
+            }
+        };
+
+        RxAssertionsNonBlock.assertThat(values)
+              .completes()
+              .oneEmissionMatches(withThreeChars);
+    }
+
+    @Test public void multipleEmissions_AreNotMatchedOnCondition() {
+        List<String> expected = Arrays.asList("These", "are", "Expected", "Values");
+        Observable<String> values = Observable.from(expected);
+
+        Condition<String> greaterThanTen = new Condition<String>() {
+            @Override public boolean matches(String value) {
+                return value != null && value.length() > 10;
+            }
+        };
+
+        RxAssertionsNonBlock.assertThat(values)
+              .completes()
+              .allItemsNotMaching(greaterThanTen);
+    }
+
+    @Test public void emissions_Contains_DesiredValues() {
+        Observable<Integer> values = Observable.range(1, 100);
+
+        RxAssertionsNonBlock.assertThat(values)
+              .completes()
+              .emits(10)
+              .emits(20);
+    }
+}

--- a/src/test/java/br/ufs/github/rxassertions/tests/UsageExamples.java
+++ b/src/test/java/br/ufs/github/rxassertions/tests/UsageExamples.java
@@ -1,0 +1,36 @@
+package br.ufs.github.rxassertions.tests;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import br.ufs.github.rxassertions.NonBlockingTestSubscriberAssertionsWrapper;
+import br.ufs.github.rxassertions.RxAssertionsNonBlock;
+import rx.Observable;
+import rx.schedulers.TestScheduler;
+
+public class UsageExamples {
+
+    @Test
+    public void testWithScheduler() throws Exception {
+        TestScheduler scheduler = new TestScheduler();
+
+        NonBlockingTestSubscriberAssertionsWrapper<Long> assertion =
+              RxAssertionsNonBlock.assertThat(
+                    Observable.interval(1, TimeUnit.MILLISECONDS, scheduler).take(3));
+        assertion
+              .notCompletes()
+              .emitsNothing()
+              .withoutErrors();
+
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.emissionsCount(1);
+
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.emissionsCount(2);
+
+        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        assertion.emissionsCount(3)
+              .completes();
+    }
+}


### PR DESCRIPTION
**Summary**
Added possibility to use `TestScheduler` with `RxAssertions`. This done by introducing a non blocking version.

**Motivation**
Let's say my observable under test looks like this: `Observable.interval(1, TimeUnit.MILLISECONDS, scheduler)`. In order to test this I could use `TestScheduler` but cannot because `RxAssertion` automatically converts observable under  test into `BlockingObservable`.

This is how my test could looks like

```
public class UsageExamples {

    @Test
    public void testWithScheduler() throws Exception {
        TestScheduler scheduler = new TestScheduler();

        NonBlockingTestSubscriberAssertionsWrapper<Long> assertion =
              RxAssertionsNonBlock.assertThat(
                    Observable.interval(1, TimeUnit.MILLISECONDS, scheduler).take(3));
        assertion
              .notCompletes()
              .emitsNothing()
              .withoutErrors();

        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
        assertion.emissionsCount(1);

        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
        assertion.emissionsCount(2);

        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
        assertion.emissionsCount(3)
              .completes();
    }
}
```

**Implementation**
I've created `RxAssertionsNonBlock` which is non blocking equivalent of `RxAssertion`. I did it in a separate class in order to keep library backward compatible.
`UsageExamples` should be removed before merging.

**Thoughts**
I believe that developer should be able to choose between `toBlocking` and `TestScheduler`. For example, time based stream can be tested only with `TestScheduler`. 

**To discuss**
- I would rename `NonBlockingTestSubscriberAssertionsWrapper` to something shorter. In this case it won't match the naming for `TestSubscriberAssertionsWrapper`
