### PR TITLE
Add expectedValues varags method

### DIFF
--- a/src/main/java/br/ufs/github/rxassertions/BlockingObservableAssert.java
+++ b/src/main/java/br/ufs/github/rxassertions/BlockingObservableAssert.java
@@ -62,6 +62,11 @@ public class BlockingObservableAssert<T> {
         return this;
     }
 
+    public BlockingObservableAssert<T> expectedValues(T... ordered) {
+        wrapper.expectedValues(ordered);
+        return this;
+    }
+
     public BlockingObservableAssert<T> expectedValues(Collection<T> ordered) {
         wrapper.expectedValues(ordered);
         return this;


### PR DESCRIPTION
This exposes the `expectedValues(T... ordered)` method in `TestSubscriberAssertionsWrapper` allowing you to write:

`assertThat(o).expectedValues("one", "two");`

rather than:

`assertThat(o).expectedValues(Arrays.asList("one", "two"));`
