### PR TITLE
Update AssertJ from 2.5.0 to 3.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 def RXJAVA_VERSION = '1.1.9'
-def ASSERTJ_VERSION = '2.5.0'
+def ASSERTJ_VERSION = '3.8.0'
 
 dependencies {
 


### PR DESCRIPTION
Due to binary incompatibilities between AssertJ 2.5.0 and 3.8.0, rxassertions doesn't work when run against the newer version of AssertJ. It needs recompiling to work, but no code changes are required. This PR bumps the gradle dependency only.